### PR TITLE
Use our own mobius3 container instead of quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.8-alpine
+
+RUN addgroup -S mobius3 && \
+    adduser -S mobius3 -G mobius3 && \
+    mkdir ~mobius3/data && \
+    chown mobius3:mobius3 ~mobius3/data
+WORKDIR /home/mobius3
+
+RUN pip install mobius3==0.0.34
+
+USER mobius3
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.8-alpine
+LABEL org.opencontainers.image.source=https://github.com/zeroae/terraform-aws-mobius3
 
 RUN addgroup -S mobius3 && \
     adduser -S mobius3 -G mobius3 && \

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ No provider.
 | bucket\_key\_prefix | The key prefix to use for the bucket objects. | `any` | n/a | yes |
 | bucket\_region | Bucket Region | `any` | n/a | yes |
 | log\_configuration | Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html | `any` | `null` | no |
-| mobius3\_image | The Mobius3 Image for S3<->FS synchronization | `string` | `"quay.io/uktrade/mobius3:v0.0.32"` | no |
+| mobius3\_image | The Mobius3 Image for S3<->FS synchronization | `string` | `"ghcr.io/zeroae/terraform-aws-mobius3:0.0.34"` | no |
 | user | The user that owns the volume. Can be any of these formats: uid, uid:gid. The default is (0:0). | `string` | `"0:0"` | no |
 | volume\_name | The volume name. | `string` | `"data"` | no |
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/zeroae/terraform-aws-mobius3/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=zeroae%2Fterraform-aws-mobius3&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,7 +20,7 @@ No provider.
 | bucket\_key\_prefix | The key prefix to use for the bucket objects. | `any` | n/a | yes |
 | bucket\_region | Bucket Region | `any` | n/a | yes |
 | log\_configuration | Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html | `any` | `null` | no |
-| mobius3\_image | The Mobius3 Image for S3<->FS synchronization | `string` | `"quay.io/uktrade/mobius3:v0.0.32"` | no |
+| mobius3\_image | The Mobius3 Image for S3<->FS synchronization | `string` | `"ghcr.io/zeroae/terraform-aws-mobius3:0.0.34"` | no |
 | user | The user that owns the volume. Can be any of these formats: uid, uid:gid. The default is (0:0). | `string` | `"0:0"` | no |
 | volume\_name | The volume name. | `string` | `"data"` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "awscli_image" {
 variable "mobius3_image" {
   description = "The Mobius3 Image for S3<->FS synchronization"
   type        = string
-  default     = "quay.io/uktrade/mobius3:v0.0.32"
+  default     = "ghcr.io/zeroae/terraform-aws-mobius3:0.0.34"
 }
 
 # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html


### PR DESCRIPTION
## what
* Use ghcr.io/zeroae/terraform-aws-mobius3 as the docker image for Mobius3.

## why
* Because quay.io goes offline more often than ghcr.io
* Because uktrade seem to have gone offline at quay.io